### PR TITLE
Use `org.infernalstudios.config` library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
+}
+
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'org.spongepowered.mixin'
@@ -103,11 +107,16 @@ dependencies {
     packIntoJar "org.infernalstudios:config:${config.CONFIG_LIB_VERSION}"
 }
 
-jar {
-    from {
-        configurations.packIntoJar.collect { it.isDirectory() ? it : zipTree(it) }
-    }
+shadowJar {
+    configurations = [project.configurations.packIntoJar]
+    relocate 'org.infernalstudios.config', 'org.infernalstudios.foodeffects.config.library'
+}
 
+reobf {
+    shadowJar {}
+}
+
+jar {
     manifest {
         attributes([
                 'Specification-Title'   : config.TITLE,
@@ -129,6 +138,8 @@ task sourcesJar(type: Jar) {
 }
 
 tasks.build.dependsOn sourcesJar
+tasks.build.dependsOn shadowJar
+tasks.build.dependsOn reobfShadowJar
 
 // Config parse function
 def parseConfig(File config) {

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,12 @@ minecraft {
                 }
             }
         }
+
+        all {
+            lazyToken('minecraft_classpath') {
+                configurations.packIntoJar.copyRecursive().resolve().collect { it.absolutePath }.join(File.pathSeparator)
+            }
+        }
     }
 }
 
@@ -79,12 +85,29 @@ mixin {
     dumpTargetOnFailure = true
 }
 
+configurations {
+    packIntoJar {
+        extendsFrom runtimeOnly
+        transitive = false
+    }
+}
+
+repositories {
+    maven { url = 'https://maven.infernalstudios.org/releases' }
+}
+
 dependencies {
     minecraft "net.minecraftforge:forge:${config.MINECRAFT_VERSION}-${config.FORGE_VERSION}"
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+    implementation "org.infernalstudios:config:${config.CONFIG_LIB_VERSION}"
+    packIntoJar "org.infernalstudios:config:${config.CONFIG_LIB_VERSION}"
 }
 
 jar {
+    from {
+        configurations.packIntoJar.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+
     manifest {
         attributes([
                 'Specification-Title'   : config.TITLE,

--- a/build.gradle
+++ b/build.gradle
@@ -71,12 +71,6 @@ minecraft {
                 }
             }
         }
-
-        all {
-            lazyToken('minecraft_classpath') {
-                configurations.packIntoJar.copyRecursive().resolve().collect { it.absolutePath }.join(File.pathSeparator)
-            }
-        }
     }
 }
 
@@ -91,13 +85,14 @@ mixin {
 
 configurations {
     packIntoJar {
-        extendsFrom runtimeOnly
         transitive = false
     }
 }
 
 repositories {
-    maven { url = 'https://maven.infernalstudios.org/releases' }
+    maven {
+        url = config.CONFIG_LIB_VERSION.endsWith('SNAPSHOT') ? 'https://maven.infernalstudios.org/snapshots' : 'https://maven.infernalstudios.org/releases' 
+    }
 }
 
 dependencies {
@@ -108,6 +103,7 @@ dependencies {
 }
 
 shadowJar {
+    classifier ''
     configurations = [project.configurations.packIntoJar]
     relocate 'org.infernalstudios.config', 'org.infernalstudios.foodeffects.config.library'
 }
@@ -117,6 +113,8 @@ reobf {
 }
 
 jar {
+    classifier 'base'
+
     manifest {
         attributes([
                 'Specification-Title'   : config.TITLE,

--- a/build.properties
+++ b/build.properties
@@ -3,6 +3,7 @@ MINECRAFT_VERSION=1.18.2
 FORGE_VERSION=40.0.19
 MAPPINGS_CHANNEL=official
 MAPPINGS_VERSION=1.18.2
+CONFIG_LIB_VERSION=2.1.1
 
 # Do not edit anything below this line, it contains base information for the project.
 GROUP=org.infernalstudios

--- a/build.properties
+++ b/build.properties
@@ -3,7 +3,7 @@ MINECRAFT_VERSION=1.18.2
 FORGE_VERSION=40.0.19
 MAPPINGS_CHANNEL=official
 MAPPINGS_VERSION=1.18.2
-CONFIG_LIB_VERSION=2.1.1
+CONFIG_LIB_VERSION=3.0.1
 
 # Do not edit anything below this line, it contains base information for the project.
 GROUP=org.infernalstudios

--- a/src/main/java/org/infernalstudios/foodeffects/EffectData.java
+++ b/src/main/java/org/infernalstudios/foodeffects/EffectData.java
@@ -1,0 +1,56 @@
+package org.infernalstudios.foodeffects;
+
+import java.util.HashMap;
+import java.util.function.Supplier;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.toml.TomlFormat;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public record EffectData(Supplier<Item> item, Supplier<MobEffect> effect, int duration, int amplifier) {
+    public Item getItem() {
+        return item.get();
+    }
+
+    public MobEffect getEffect() {
+        return effect.get();
+    }
+    
+    public int getDuration() {
+        return duration;
+    }
+    
+    public int getAmplifier() {
+        return amplifier;
+    }
+
+    public Config toConfig() {
+        CommentedConfig config = CommentedConfig.of(() -> new HashMap<>(4), TomlFormat.instance());
+
+        config.set("item", this.getItem().getRegistryName().toString());
+        config.set("effect", this.getEffect().getRegistryName().toString());
+        config.set("duration", (double) this.getDuration() / 20);
+        config.set("amplifier", this.getAmplifier());
+
+        config.setComment("item", " Determines what item this effect is applied to.");
+        config.setComment("effect", " Determines what effect consuming the item will give in addition to any existing effects.");
+        config.setComment("duration", " Determines how long the effect lasts. If set to 0, the effect will be removed.\n Range: [0, 1000000]");
+        config.setComment("amplifier", " Determines how strong the effect is. Amplifiers start at 0.\n Range: [0, 255]");
+        
+        return config;
+    }
+
+    public static EffectData fromConfig(Config config) {
+        return new EffectData(
+            () -> ForgeRegistries.ITEMS.getValue(ResourceLocation.tryParse(config.<String>get("item"))),
+            () -> ForgeRegistries.MOB_EFFECTS.getValue(ResourceLocation.tryParse(config.<String>get("effect"))),
+            (int) (config.<Number>get("duration").doubleValue() * 20),
+            config.getInt("amplifier")
+        );
+    }
+}

--- a/src/main/java/org/infernalstudios/foodeffects/FoodEffects.java
+++ b/src/main/java/org/infernalstudios/foodeffects/FoodEffects.java
@@ -17,10 +17,12 @@
 package org.infernalstudios.foodeffects;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 import com.electronwill.nightconfig.core.io.ParsingException;
 
 import org.infernalstudios.config.Config;
+import org.infernalstudios.config.Config.ReloadStage;
 import org.infernalstudios.foodeffects.config.FoodEffectsConfig;
 
 import net.minecraftforge.common.MinecraftForge;
@@ -43,14 +45,26 @@ public class FoodEffects {
         MinecraftForge.EVENT_BUS.register(this);
         MinecraftForge.EVENT_BUS.register(new FoodEffectsEvents());
 
+        Config config;
         try {
-            Config
+            config = Config
                 .builder(FMLPaths.CONFIGDIR.get().resolve("foodeffects-common.toml"))
-                .loadClass(FoodEffectsConfig.General.class)
-                .loadClass(FoodEffectsConfig.Effects.class)
+                .loadClass(FoodEffectsConfig.class)
                 .build();
         } catch (IllegalStateException | IllegalArgumentException | IOException | ParsingException e) {
             throw new RuntimeException("Failed to load Food Effects config", e);
         }
+
+        config.onReload(stage -> {
+            if (stage.equals(ReloadStage.POST)) {
+                FoodEffectsEvents.EFFECT_MAP.clear();
+                for (EffectData effect : FoodEffectsConfig.effects) {
+                    if (!FoodEffectsEvents.EFFECT_MAP.containsKey(effect.getItem())) {
+                        FoodEffectsEvents.EFFECT_MAP.put(effect.getItem(), new ArrayList<>());
+                    }
+                    FoodEffectsEvents.EFFECT_MAP.get(effect.getItem()).add(effect);
+                }
+            }
+        });
     }
 }

--- a/src/main/java/org/infernalstudios/foodeffects/FoodEffects.java
+++ b/src/main/java/org/infernalstudios/foodeffects/FoodEffects.java
@@ -16,12 +16,18 @@
 
 package org.infernalstudios.foodeffects;
 
+import java.io.IOException;
+
+import com.electronwill.nightconfig.core.io.ParsingException;
+
+import org.infernalstudios.config.Config;
 import org.infernalstudios.foodeffects.config.FoodEffectsConfig;
+
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.IExtensionPoint.DisplayTest;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.network.NetworkConstants;
 
 @Mod(FoodEffects.MOD_ID)
@@ -37,6 +43,14 @@ public class FoodEffects {
         MinecraftForge.EVENT_BUS.register(this);
         MinecraftForge.EVENT_BUS.register(new FoodEffectsEvents());
 
-        context.registerConfig(ModConfig.Type.COMMON, FoodEffectsConfig.COMMON_SPEC);
+        try {
+            Config
+                .builder(FMLPaths.CONFIGDIR.get().resolve("foodeffects-common.toml"))
+                .loadClass(FoodEffectsConfig.General.class)
+                .loadClass(FoodEffectsConfig.Effects.class)
+                .build();
+        } catch (IllegalStateException | IllegalArgumentException | IOException | ParsingException e) {
+            throw new RuntimeException("Failed to load Food Effects config", e);
+        }
     }
 }

--- a/src/main/java/org/infernalstudios/foodeffects/FoodEffectsEvents.java
+++ b/src/main/java/org/infernalstudios/foodeffects/FoodEffectsEvents.java
@@ -17,11 +17,13 @@
 package org.infernalstudios.foodeffects;
 
 import static net.minecraftforge.registries.ForgeRegistries.MOB_EFFECTS;
-import static org.infernalstudios.foodeffects.config.FoodEffectsConfig.COMMON;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
+
+import org.infernalstudios.foodeffects.config.FoodEffectsConfig.Effects;
+import org.infernalstudios.foodeffects.config.FoodEffectsConfig.General;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
@@ -41,7 +43,7 @@ public class FoodEffectsEvents {
     public void onLivingEntityUseItemStart(LivingEntityUseItemEvent.Start event) {
         ItemStack stack = event.getItem();
 
-        if ((stack.getItem() == Items.COOKIE || stack.getItem() == Items.SWEET_BERRIES) && COMMON.EAT_COOKIES_BERRIES_FAST.get()) {
+        if ((stack.getItem() == Items.COOKIE || stack.getItem() == Items.SWEET_BERRIES) && General.eat_cookies_berries_fast) {
             // Default is 32, 16 is twice as fast, just like Dried Kelp
             event.setDuration(16);
         }
@@ -54,65 +56,65 @@ public class FoodEffectsEvents {
         EFFECT_MAP.put(
             Items.PUFFERFISH,
             new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(COMMON.PUFFERFISH_EFFECT.get())),
-                () -> (int)(COMMON.PUFFERFISH_EFFECT_DURATION.get() * 20),
-                () -> COMMON.PUFFERFISH_EFFECT_AMPLIFIER.get()
+                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.pufferfish_effect)),
+                () -> (int)(Effects.pufferfish_effect_duration * 20),
+                () -> Effects.pufferfish_effect_amplifier
             )
         );
         EFFECT_MAP.put(
             Items.MUSHROOM_STEW,
             new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(COMMON.MUSHROOM_STEW_EFFECT.get())),
-                () -> (int)(COMMON.MUSHROOM_STEW_EFFECT_DURATION.get() * 20),
-                () -> COMMON.MUSHROOM_STEW_EFFECT_AMPLIFIER.get()
+                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.mushroom_stew_effect)),
+                () -> (int)(Effects.mushroom_stew_effect_duration * 20),
+                () -> Effects.mushroom_stew_effect_amplifier
             )
         );
         EFFECT_MAP.put(
             Items.RABBIT_STEW,
             new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(COMMON.RABBIT_STEW_EFFECT.get())),
-                () -> (int)(COMMON.RABBIT_STEW_EFFECT_DURATION.get() * 20),
-                () -> COMMON.RABBIT_STEW_EFFECT_AMPLIFIER.get()
+                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.rabbit_stew_effect)),
+                () -> (int)(Effects.rabbit_stew_effect_duration * 20),
+                () -> Effects.rabbit_stew_effect_amplifier
             )
         );
         EFFECT_MAP.put(
             Items.BEETROOT_SOUP,
             new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(COMMON.BEETROOT_SOUP_EFFECT.get())),
-                () -> (int)(COMMON.BEETROOT_SOUP_EFFECT_DURATION.get() * 20),
-                () -> COMMON.BEETROOT_SOUP_EFFECT_AMPLIFIER.get()
+                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.beetroot_soup_effect)),
+                () -> (int)(Effects.beetroot_soup_effect_duration * 20),
+                () -> Effects.beetroot_soup_effect_amplifier
             )
         );
         EFFECT_MAP.put(
             Items.COOKIE,
             new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(COMMON.COOKIE_EFFECT.get())),
-                () -> (int)(COMMON.COOKIE_EFFECT_DURATION.get() * 20),
-                () -> COMMON.COOKIE_EFFECT_AMPLIFIER.get()
+                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.cookie_effect)),
+                () -> (int)(Effects.cookie_effect_duration * 20),
+                () -> Effects.cookie_effect_amplifier
             )
         );
         EFFECT_MAP.put(
             Items.PUMPKIN_PIE,
             new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(COMMON.PUMPKIN_PIE_EFFECT.get())),
-                () -> (int)(COMMON.PUMPKIN_PIE_EFFECT_DURATION.get() * 20),
-                () -> COMMON.PUMPKIN_PIE_EFFECT_AMPLIFIER.get()
+                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.pumpkin_pie_effect)),
+                () -> (int)(Effects.pumpkin_pie_effect_duration * 20),
+                () -> Effects.pumpkin_pie_effect_amplifier
             )
         );
         EFFECT_MAP.put(
             Items.HONEY_BOTTLE,
             new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(COMMON.HONEY_BOTTLE_EFFECT.get())),
-                () -> (int)(COMMON.HONEY_BOTTLE_EFFECT_DURATION.get() * 20),
-                () -> COMMON.HONEY_BOTTLE_EFFECT_AMPLIFIER.get()
+                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.honey_bottle_effect)),
+                () -> (int)(Effects.honey_bottle_effect_duration * 20),
+                () -> Effects.honey_bottle_effect_amplifier
             )
         );
         EFFECT_MAP.put(
             Items.BAKED_POTATO,
             new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(COMMON.BAKED_POTATO_EFFECT.get())),
-                () -> (int)(COMMON.BAKED_POTATO_EFFECT_DURATION.get() * 20),
-                () -> COMMON.BAKED_POTATO_EFFECT_AMPLIFIER.get()
+                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.baked_potato_effect)),
+                () -> (int)(Effects.baked_potato_effect_duration * 20),
+                () -> Effects.baked_potato_effect_amplifier
             )
         );
     }

--- a/src/main/java/org/infernalstudios/foodeffects/FoodEffectsEvents.java
+++ b/src/main/java/org/infernalstudios/foodeffects/FoodEffectsEvents.java
@@ -16,17 +16,12 @@
 
 package org.infernalstudios.foodeffects;
 
-import static net.minecraftforge.registries.ForgeRegistries.MOB_EFFECTS;
-
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.concurrent.ConcurrentHashMap;
 
-import org.infernalstudios.foodeffects.config.FoodEffectsConfig.Effects;
-import org.infernalstudios.foodeffects.config.FoodEffectsConfig.General;
+import org.infernalstudios.foodeffects.config.FoodEffectsConfig;
 
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.player.Player;
@@ -36,6 +31,13 @@ import net.minecraft.world.item.Items;
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLConstructModEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLDedicatedServerSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
+import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
 
 @EventBusSubscriber(modid = FoodEffects.MOD_ID)
 public class FoodEffectsEvents {
@@ -43,102 +45,42 @@ public class FoodEffectsEvents {
     public void onLivingEntityUseItemStart(LivingEntityUseItemEvent.Start event) {
         ItemStack stack = event.getItem();
 
-        if ((stack.getItem() == Items.COOKIE || stack.getItem() == Items.SWEET_BERRIES) && General.eat_cookies_berries_fast) {
+        if ((stack.getItem() == Items.COOKIE || stack.getItem() == Items.SWEET_BERRIES) && FoodEffectsConfig.eat_cookies_berries_fast) {
             // Default is 32, 16 is twice as fast, just like Dried Kelp
             event.setDuration(16);
         }
     }
 
-    private static record EffectData(Supplier<MobEffect> effect, Supplier<Integer> duration, Supplier<Integer> amplifier) {}
-    
-    private static final Map<Item, EffectData> EFFECT_MAP = new HashMap<>();
-    static {
-        EFFECT_MAP.put(
-            Items.PUFFERFISH,
-            new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.pufferfish_effect)),
-                () -> (int)(Effects.pufferfish_effect_duration * 20),
-                () -> Effects.pufferfish_effect_amplifier
-            )
-        );
-        EFFECT_MAP.put(
-            Items.MUSHROOM_STEW,
-            new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.mushroom_stew_effect)),
-                () -> (int)(Effects.mushroom_stew_effect_duration * 20),
-                () -> Effects.mushroom_stew_effect_amplifier
-            )
-        );
-        EFFECT_MAP.put(
-            Items.RABBIT_STEW,
-            new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.rabbit_stew_effect)),
-                () -> (int)(Effects.rabbit_stew_effect_duration * 20),
-                () -> Effects.rabbit_stew_effect_amplifier
-            )
-        );
-        EFFECT_MAP.put(
-            Items.BEETROOT_SOUP,
-            new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.beetroot_soup_effect)),
-                () -> (int)(Effects.beetroot_soup_effect_duration * 20),
-                () -> Effects.beetroot_soup_effect_amplifier
-            )
-        );
-        EFFECT_MAP.put(
-            Items.COOKIE,
-            new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.cookie_effect)),
-                () -> (int)(Effects.cookie_effect_duration * 20),
-                () -> Effects.cookie_effect_amplifier
-            )
-        );
-        EFFECT_MAP.put(
-            Items.PUMPKIN_PIE,
-            new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.pumpkin_pie_effect)),
-                () -> (int)(Effects.pumpkin_pie_effect_duration * 20),
-                () -> Effects.pumpkin_pie_effect_amplifier
-            )
-        );
-        EFFECT_MAP.put(
-            Items.HONEY_BOTTLE,
-            new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.honey_bottle_effect)),
-                () -> (int)(Effects.honey_bottle_effect_duration * 20),
-                () -> Effects.honey_bottle_effect_amplifier
-            )
-        );
-        EFFECT_MAP.put(
-            Items.BAKED_POTATO,
-            new EffectData(
-                () -> MOB_EFFECTS.getValue(new ResourceLocation(Effects.baked_potato_effect)),
-                () -> (int)(Effects.baked_potato_effect_duration * 20),
-                () -> Effects.baked_potato_effect_amplifier
-            )
-        );
-    }
-
+    protected static final Map<Item, List<EffectData>> EFFECT_MAP = new ConcurrentHashMap<>();
 
     @SubscribeEvent
     public void onLivingEntityUseItemFinish(LivingEntityUseItemEvent.Finish event) {
         if (event.getEntity() instanceof Player player) {
-            ItemStack stack = event.getItem();
-    
-            if (stack.getItem() == Items.DRIED_KELP) {
-                player.removeEffect(MobEffects.POISON);
-                player.removeEffect(MobEffects.CONFUSION);
-                player.removeEffect(MobEffects.BLINDNESS);
+            onEat(player, event.getItem().getItem());
+        }
+    }
+
+    public static void onEat(Player player, Item item) {
+        if (item == Items.DRIED_KELP) {
+            player.removeEffect(MobEffects.POISON);
+            player.removeEffect(MobEffects.CONFUSION);
+            player.removeEffect(MobEffects.BLINDNESS);
+        }
+        List<EffectData> effectData = EFFECT_MAP.get(item);
+        if (effectData == null) {
+            return;
+        }
+        for (EffectData effect : effectData) {
+            if (effect.getDuration() == 0) {
+                player.removeEffect(effect.getEffect());
             } else {
-                EffectData effectData = EFFECT_MAP.get(stack.getItem());
-                if (effectData != null) {
-                    MobEffectInstance effect = new MobEffectInstance(
-                        effectData.effect.get(),
-                        effectData.duration.get(),
-                        effectData.amplifier.get()
-                    );
-                    player.addEffect(effect);
-                }
+                player.addEffect(
+                    new MobEffectInstance(
+                        effect.getEffect(),
+                        effect.getDuration(),
+                        effect.getAmplifier()
+                    )
+                );
             }
         }
     }

--- a/src/main/java/org/infernalstudios/foodeffects/config/FoodEffectsConfig.java
+++ b/src/main/java/org/infernalstudios/foodeffects/config/FoodEffectsConfig.java
@@ -16,117 +16,40 @@
 
 package org.infernalstudios.foodeffects.config;
 
-import org.infernalstudios.config.annotation.Category;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.infernalstudios.config.annotation.Configurable;
-import org.infernalstudios.config.annotation.DoubleRange;
-import org.infernalstudios.config.annotation.IntegerRange;
+import org.infernalstudios.foodeffects.EffectData;
+
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.item.Items;
 
 public class FoodEffectsConfig {
-    @Category("General")
-    public static class General {
-        @Configurable(description = "Determines if Sweet Berries and Cookies should be eaten as fast as Dried Kelp")
-        public static boolean eat_cookies_berries_fast = true;
+    static {
     }
 
-    @Category("Effects")
-    public static class Effects {
-        @Configurable(description = "Determines what effect consuming Pufferfish will give (in addition to existing effects)")
-        public static String pufferfish_effect = "minecraft:water_breathing";
+    @Configurable(description = "Determines if Sweet Berries and Cookies should be eaten as fast as Dried Kelp", category = "General")
+    public static boolean eat_cookies_berries_fast = true;
 
-        @Configurable(description = "Determines how long (in seconds) the Pufferfish Food Effect will last")
-        @DoubleRange(min = 0, max = 1000000)
-        public static double pufferfish_effect_duration = 10.0;
-
-        @Configurable(description = "Determines what level the Pufferfish Food Effect will be (starting at 0 as level 1)")
-        @IntegerRange(min = 0, max = 255)
-        public static int pufferfish_effect_amplifier = 0;
-
-        @Configurable(description = "Determines what effect consuming Mushroom Stew will give")
-        public static String mushroom_stew_effect = "minecraft:regeneration";
-
-        @Configurable(description = "Determines how long (in seconds) the Mushroom Stew Food Effect will last")
-        @DoubleRange(min = 0, max = 1000000)
-        public static double mushroom_stew_effect_duration = 5.0;
-
-        @Configurable(description = "Determines what level the Mushroom Stew Food Effect will be (starting at 0 as level 1)")
-        @IntegerRange(min = 0, max = 255)
-        public static int mushroom_stew_effect_amplifier = 1;
-
-        @Configurable(description = "Determines what effect consuming Rabbit Stew will give")
-        public static String rabbit_stew_effect = "minecraft:jump_boost";
-
-        @Configurable(description = "Determines how long (in seconds) the Rabbit Stew Food Effect will last")
-        @DoubleRange(min = 0, max = 1000000)
-        public static double rabbit_stew_effect_duration = 10.0;
-
-        @Configurable(description = "Determines what level the Rabbit Stew Food Effect will be (starting at 0 as level 1)")
-        @IntegerRange(min = 0, max = 255)
-        public static int rabbit_stew_effect_amplifier = 1;
-
-        @Configurable(description = "Determines what effect consuming Beetroot Soup will give")
-        public static String beetroot_soup_effect = "minecraft:health_boost";
-
-        @Configurable(description = "Determines how long (in seconds) the Beetroot Soup Food Effect will last")
-        @DoubleRange(min = 0, max = 1000000)
-        public static double beetroot_soup_effect_duration = 30.0;
-
-        @Configurable(description = "Determines what level the Beetroot Soup Food Effect will be (starting at 0 as level 1)")
-        @IntegerRange(min = 0, max = 255)
-        public static int beetroot_soup_effect_amplifier = 0;
-
-        @Configurable(description = "Determines what effect consuming Cookies will give")
-        public static String cookie_effect = "minecraft:speed";
-
-        @Configurable(description = "Determines how long (in seconds) the Cookie Food Effect will last")
-        @DoubleRange(min = 0, max = 1000000)
-        public static double cookie_effect_duration = 10.0;
-
-        @Configurable(description = "Determines what level the Cookie Food Effect will be (starting at 0 as level 1)")
-        @IntegerRange(min = 0, max = 255)
-        public static int cookie_effect_amplifier = 0;
-
-        @Configurable(description = "Determines what effect consuming Pumpkin Pie will give")
-        public static String pumpkin_pie_effect = "minecraft:haste";
-
-        @Configurable(description = "Determines how long (in seconds) the Pumpkin Pie Food Effect will last")
-        @DoubleRange(min = 0, max = 1000000)
-        public static double pumpkin_pie_effect_duration = 15.0;
-
-        @Configurable(description = "Determines what level the Pumpkin Pie Food Effect will be (starting at 0 as level 1)")
-        @IntegerRange(min = 0, max = 255)
-        public static int pumpkin_pie_effect_amplifier = 1;
-
-        @Configurable(description = "Determines what effect consuming Honey Bottles will give")
-        public static String honey_bottle_effect = "minecraft:instant_health";
-
-        @Configurable(description = "Determines how long (in seconds) the Honey Bottle Food Effect will last")
-        @DoubleRange(min = 0, max = 1000000)
-        public static double honey_bottle_effect_duration = 0.05;
-
-        @Configurable(description = "Determines what level the Honey Bottle Food Effect will be (starting at 0 as level 1)")
-        @IntegerRange(min = 0, max = 255)
-        public static int honey_bottle_effect_amplifier = 0;
-
-        @Configurable(description = "Determines what effect consuming Baked Potatoes will give")
-        public static String baked_potato_effect = "minecraft:strength";
-
-        @Configurable(description = "Determines how long (in seconds) the Baked Potatoes Food Effect will last")
-        @DoubleRange(min = 0, max = 1000000)
-        public static double baked_potato_effect_duration = 10.0;
-
-        @Configurable(description = "Determines what level the Baked Potato Food Effect will be (starting at 0 as level 1)")
-        @IntegerRange(min = 0, max = 255)
-        public static int baked_potato_effect_amplifier = 0;
-
-        @Configurable(description = "Determines what effect consuming a slice of Cake will give")
-        public static String cake_effect = "minecraft:speed";
-
-        @Configurable(description = "Determines how long (in seconds) the Cake Food Effect will last")
-        @DoubleRange(min = 0, max = 1000000)
-        public static double cake_effect_duration = 20.0;
-
-        @Configurable(description = "Determines what level the Cake Food Effect will be (starting at 0 as level 1)")
-        @IntegerRange(min = 0, max = 255)
-        public static int cake_effect_amplifier = 1;
-    }
+    @Configurable(handler = "org.infernalstudios.foodeffects.config.handler.EffectDataListConfigHandler.INSTANCE")
+    public static List<EffectData> effects = new ArrayList<>(List.of(
+        new EffectData(() -> Items.BAKED_POTATO,  () -> MobEffects.DAMAGE_BOOST,    200, 0),
+        new EffectData(() -> Items.BEETROOT_SOUP, () -> MobEffects.HEALTH_BOOST,    600, 0),
+        new EffectData(() -> Items.CAKE,          () -> MobEffects.MOVEMENT_SPEED,  400, 1),
+        new EffectData(() -> Items.COOKIE,        () -> MobEffects.MOVEMENT_SPEED,  200, 0),
+        new EffectData(() -> Items.DRIED_KELP,    () -> MobEffects.BLINDNESS,       0,   0),
+        new EffectData(() -> Items.DRIED_KELP,    () -> MobEffects.CONFUSION,       0,   0),
+        new EffectData(() -> Items.DRIED_KELP,    () -> MobEffects.POISON,          0,   0),
+        new EffectData(() -> Items.HONEY_BOTTLE,  () -> MobEffects.HEAL,            1,   0),
+        new EffectData(() -> Items.MUSHROOM_STEW, () -> MobEffects.REGENERATION,    100, 0),
+        new EffectData(() -> Items.PUFFERFISH,    () -> MobEffects.WATER_BREATHING, 200, 0),
+        new EffectData(() -> Items.PUMPKIN_PIE,   () -> MobEffects.DIG_SPEED,       300, 1),
+        new EffectData(() -> Items.RABBIT_STEW,   () -> MobEffects.JUMP,            200, 1)
+    )) {
+        @Override
+        public String toString() {
+            return "";
+        }
+    };
 }

--- a/src/main/java/org/infernalstudios/foodeffects/config/FoodEffectsConfig.java
+++ b/src/main/java/org/infernalstudios/foodeffects/config/FoodEffectsConfig.java
@@ -16,177 +16,117 @@
 
 package org.infernalstudios.foodeffects.config;
 
-import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.common.ForgeConfigSpec.Builder;
-import org.apache.commons.lang3.tuple.Pair;
+import org.infernalstudios.config.annotation.Category;
+import org.infernalstudios.config.annotation.Configurable;
+import org.infernalstudios.config.annotation.DoubleRange;
+import org.infernalstudios.config.annotation.IntegerRange;
 
 public class FoodEffectsConfig {
-    public static final ForgeConfigSpec COMMON_SPEC;
-    public static final FoodEffectsConfig COMMON;
-
-    static {
-        final Pair<FoodEffectsConfig, ForgeConfigSpec> specPair = new ForgeConfigSpec.Builder().configure(FoodEffectsConfig::new);
-        COMMON_SPEC = specPair.getRight();
-        COMMON = specPair.getLeft();
+    @Category("General")
+    public static class General {
+        @Configurable(description = "Determines if Sweet Berries and Cookies should be eaten as fast as Dried Kelp")
+        public static boolean eat_cookies_berries_fast = true;
     }
 
-    public final ForgeConfigSpec.BooleanValue EAT_COOKIES_BERRIES_FAST;
+    @Category("Effects")
+    public static class Effects {
+        @Configurable(description = "Determines what effect consuming Pufferfish will give (in addition to existing effects)")
+        public static String pufferfish_effect = "minecraft:water_breathing";
 
-    public final ForgeConfigSpec.ConfigValue<String> PUFFERFISH_EFFECT;
-    public final ForgeConfigSpec.DoubleValue PUFFERFISH_EFFECT_DURATION;
-    public final ForgeConfigSpec.IntValue PUFFERFISH_EFFECT_AMPLIFIER;
+        @Configurable(description = "Determines how long (in seconds) the Pufferfish Food Effect will last")
+        @DoubleRange(min = 0, max = 1000000)
+        public static double pufferfish_effect_duration = 10.0;
 
-    public final ForgeConfigSpec.ConfigValue<String> MUSHROOM_STEW_EFFECT;
-    public final ForgeConfigSpec.DoubleValue MUSHROOM_STEW_EFFECT_DURATION;
-    public final ForgeConfigSpec.IntValue MUSHROOM_STEW_EFFECT_AMPLIFIER;
+        @Configurable(description = "Determines what level the Pufferfish Food Effect will be (starting at 0 as level 1)")
+        @IntegerRange(min = 0, max = 255)
+        public static int pufferfish_effect_amplifier = 0;
 
-    public final ForgeConfigSpec.ConfigValue<String> RABBIT_STEW_EFFECT;
-    public final ForgeConfigSpec.DoubleValue RABBIT_STEW_EFFECT_DURATION;
-    public final ForgeConfigSpec.IntValue RABBIT_STEW_EFFECT_AMPLIFIER;
+        @Configurable(description = "Determines what effect consuming Mushroom Stew will give")
+        public static String mushroom_stew_effect = "minecraft:regeneration";
 
-    public final ForgeConfigSpec.ConfigValue<String> BEETROOT_SOUP_EFFECT;
-    public final ForgeConfigSpec.DoubleValue BEETROOT_SOUP_EFFECT_DURATION;
-    public final ForgeConfigSpec.IntValue BEETROOT_SOUP_EFFECT_AMPLIFIER;
+        @Configurable(description = "Determines how long (in seconds) the Mushroom Stew Food Effect will last")
+        @DoubleRange(min = 0, max = 1000000)
+        public static double mushroom_stew_effect_duration = 5.0;
 
-    public final ForgeConfigSpec.ConfigValue<String> COOKIE_EFFECT;
-    public final ForgeConfigSpec.DoubleValue COOKIE_EFFECT_DURATION;
-    public final ForgeConfigSpec.IntValue COOKIE_EFFECT_AMPLIFIER;
+        @Configurable(description = "Determines what level the Mushroom Stew Food Effect will be (starting at 0 as level 1)")
+        @IntegerRange(min = 0, max = 255)
+        public static int mushroom_stew_effect_amplifier = 1;
 
-    public final ForgeConfigSpec.ConfigValue<String> PUMPKIN_PIE_EFFECT;
-    public final ForgeConfigSpec.DoubleValue PUMPKIN_PIE_EFFECT_DURATION;
-    public final ForgeConfigSpec.IntValue PUMPKIN_PIE_EFFECT_AMPLIFIER;
+        @Configurable(description = "Determines what effect consuming Rabbit Stew will give")
+        public static String rabbit_stew_effect = "minecraft:jump_boost";
 
-    public final ForgeConfigSpec.ConfigValue<String> HONEY_BOTTLE_EFFECT;
-    public final ForgeConfigSpec.DoubleValue HONEY_BOTTLE_EFFECT_DURATION;
-    public final ForgeConfigSpec.IntValue HONEY_BOTTLE_EFFECT_AMPLIFIER;
+        @Configurable(description = "Determines how long (in seconds) the Rabbit Stew Food Effect will last")
+        @DoubleRange(min = 0, max = 1000000)
+        public static double rabbit_stew_effect_duration = 10.0;
 
-    public final ForgeConfigSpec.ConfigValue<String> BAKED_POTATO_EFFECT;
-    public final ForgeConfigSpec.DoubleValue BAKED_POTATO_EFFECT_DURATION;
-    public final ForgeConfigSpec.IntValue BAKED_POTATO_EFFECT_AMPLIFIER;
+        @Configurable(description = "Determines what level the Rabbit Stew Food Effect will be (starting at 0 as level 1)")
+        @IntegerRange(min = 0, max = 255)
+        public static int rabbit_stew_effect_amplifier = 1;
 
-    public final ForgeConfigSpec.ConfigValue<String> CAKE_EFFECT;
-    public final ForgeConfigSpec.DoubleValue CAKE_EFFECT_DURATION;
-    public final ForgeConfigSpec.IntValue CAKE_EFFECT_AMPLIFIER;
+        @Configurable(description = "Determines what effect consuming Beetroot Soup will give")
+        public static String beetroot_soup_effect = "minecraft:health_boost";
 
-    public FoodEffectsConfig(Builder builder) {
-        builder.push("General");
+        @Configurable(description = "Determines how long (in seconds) the Beetroot Soup Food Effect will last")
+        @DoubleRange(min = 0, max = 1000000)
+        public static double beetroot_soup_effect_duration = 30.0;
 
-        EAT_COOKIES_BERRIES_FAST = builder
-                .comment("Determines if Sweet Berries and Cookies should be eaten as fast as Dried Kelp")
-                .define("eat_cookies_berries_fast", true);
+        @Configurable(description = "Determines what level the Beetroot Soup Food Effect will be (starting at 0 as level 1)")
+        @IntegerRange(min = 0, max = 255)
+        public static int beetroot_soup_effect_amplifier = 0;
 
-        builder.pop();
+        @Configurable(description = "Determines what effect consuming Cookies will give")
+        public static String cookie_effect = "minecraft:speed";
 
-        builder.push("Effects");
+        @Configurable(description = "Determines how long (in seconds) the Cookie Food Effect will last")
+        @DoubleRange(min = 0, max = 1000000)
+        public static double cookie_effect_duration = 10.0;
 
-        PUFFERFISH_EFFECT = builder
-                .comment("Determines what effect consuming Pufferfish will give (in addition to existing effects)")
-                .define("pufferfish_effect", "minecraft:water_breathing");
+        @Configurable(description = "Determines what level the Cookie Food Effect will be (starting at 0 as level 1)")
+        @IntegerRange(min = 0, max = 255)
+        public static int cookie_effect_amplifier = 0;
 
-        PUFFERFISH_EFFECT_DURATION = builder
-                .comment("Determines how long (in seconds) the Pufferfish Food Effect will last")
-                .defineInRange("pufferfish_effect_duration", 10.0, 0, 1000000);
+        @Configurable(description = "Determines what effect consuming Pumpkin Pie will give")
+        public static String pumpkin_pie_effect = "minecraft:haste";
 
-        PUFFERFISH_EFFECT_AMPLIFIER = builder
-                .comment("Determines what level the Pufferfish Food Effect will be (starting at 0 as level 1)")
-                .defineInRange("pufferfish_effect_amplifier", 0, 0, 255);
+        @Configurable(description = "Determines how long (in seconds) the Pumpkin Pie Food Effect will last")
+        @DoubleRange(min = 0, max = 1000000)
+        public static double pumpkin_pie_effect_duration = 15.0;
 
-        MUSHROOM_STEW_EFFECT = builder
-                .comment("Determines what effect consuming Mushroom Stew will give")
-                .define("mushroom_stew_effect", "minecraft:regeneration");
+        @Configurable(description = "Determines what level the Pumpkin Pie Food Effect will be (starting at 0 as level 1)")
+        @IntegerRange(min = 0, max = 255)
+        public static int pumpkin_pie_effect_amplifier = 1;
 
-        MUSHROOM_STEW_EFFECT_DURATION = builder
-                .comment("Determines how long (in seconds) the Mushroom Stew Food Effect will last")
-                .defineInRange("mushroom_stew_effect_duration", 5.0, 0, 1000000);
+        @Configurable(description = "Determines what effect consuming Honey Bottles will give")
+        public static String honey_bottle_effect = "minecraft:instant_health";
 
-        MUSHROOM_STEW_EFFECT_AMPLIFIER = builder
-                .comment("Determines what level the Mushroom Stew Food Effect will be (starting at 0 as level 1)")
-                .defineInRange("mushroom_stew_effect_amplifier", 1, 0, 255);
+        @Configurable(description = "Determines how long (in seconds) the Honey Bottle Food Effect will last")
+        @DoubleRange(min = 0, max = 1000000)
+        public static double honey_bottle_effect_duration = 0.05;
 
-        RABBIT_STEW_EFFECT = builder
-                .comment("Determines what effect consuming Rabbit Stew will give")
-                .define("rabbit_stew_effect", "minecraft:jump_boost");
+        @Configurable(description = "Determines what level the Honey Bottle Food Effect will be (starting at 0 as level 1)")
+        @IntegerRange(min = 0, max = 255)
+        public static int honey_bottle_effect_amplifier = 0;
 
-        RABBIT_STEW_EFFECT_DURATION = builder
-                .comment("Determines how long (in seconds) the Rabbit Stew Food Effect will last")
-                .defineInRange("rabbit_stew_effect_duration", 10.0, 0, 1000000);
+        @Configurable(description = "Determines what effect consuming Baked Potatoes will give")
+        public static String baked_potato_effect = "minecraft:strength";
 
-        RABBIT_STEW_EFFECT_AMPLIFIER = builder
-                .comment("Determines what level the Rabbit Stew Food Effect will be (starting at 0 as level 1)")
-                .defineInRange("rabbit_stew_effect_amplifier", 1, 0, 255);
+        @Configurable(description = "Determines how long (in seconds) the Baked Potatoes Food Effect will last")
+        @DoubleRange(min = 0, max = 1000000)
+        public static double baked_potato_effect_duration = 10.0;
 
-        BEETROOT_SOUP_EFFECT = builder
-                .comment("Determines what effect consuming Beetroot Soup will give")
-                .define("beetroot_soup_effect", "minecraft:health_boost");
+        @Configurable(description = "Determines what level the Baked Potato Food Effect will be (starting at 0 as level 1)")
+        @IntegerRange(min = 0, max = 255)
+        public static int baked_potato_effect_amplifier = 0;
 
-        BEETROOT_SOUP_EFFECT_DURATION = builder
-                .comment("Determines how long (in seconds) the Beetroot Soup Food Effect will last")
-                .defineInRange("beetroot_soup_effect_duration", 30.0, 0, 1000000);
+        @Configurable(description = "Determines what effect consuming a slice of Cake will give")
+        public static String cake_effect = "minecraft:speed";
 
-        BEETROOT_SOUP_EFFECT_AMPLIFIER = builder
-                .comment("Determines what level the Beetroot Soup Food Effect will be (starting at 0 as level 1)")
-                .defineInRange("beetroot_soup_effect_amplifier", 0, 0, 255);
+        @Configurable(description = "Determines how long (in seconds) the Cake Food Effect will last")
+        @DoubleRange(min = 0, max = 1000000)
+        public static double cake_effect_duration = 20.0;
 
-        COOKIE_EFFECT = builder
-                .comment("Determines what effect consuming Cookies will give")
-                .define("cookie_effect", "minecraft:speed");
-
-        COOKIE_EFFECT_DURATION = builder
-                .comment("Determines how long (in seconds) the Cookie Food Effect will last")
-                .defineInRange("cookie_effect_duration", 10.0, 0, 1000000);
-
-        COOKIE_EFFECT_AMPLIFIER = builder
-                .comment("Determines what level the Cookie Food Effect will be (starting at 0 as level 1)")
-                .defineInRange("cookie_effect_amplifier", 0, 0, 255);
-
-        PUMPKIN_PIE_EFFECT = builder
-                .comment("Determines what effect consuming Pumpkin Pie will give")
-                .define("pumpkin_pie_effect", "minecraft:haste");
-
-        PUMPKIN_PIE_EFFECT_DURATION = builder
-                .comment("Determines how long (in seconds) the Pumpkin Pie Food Effect will last")
-                .defineInRange("pumpkin_pie_effect_duration", 15.0, 0, 1000000);
-
-        PUMPKIN_PIE_EFFECT_AMPLIFIER = builder
-                .comment("Determines what level the Pumpkin Pie Food Effect will be (starting at 0 as level 1)")
-                .defineInRange("pumpkin_pie_effect_amplifier", 1, 0, 255);
-
-        HONEY_BOTTLE_EFFECT = builder
-                .comment("Determines what effect consuming Honey Bottles will give")
-                .define("honey_bottle_effect", "minecraft:instant_health");
-
-        HONEY_BOTTLE_EFFECT_DURATION = builder
-                .comment("Determines how long (in seconds) the Honey Bottle Food Effect will last")
-                .defineInRange("honey_bottle_effect_duration", 0.05, 0, 1000000);
-
-        HONEY_BOTTLE_EFFECT_AMPLIFIER = builder
-                .comment("Determines what level the Honey Bottle Food Effect will be (starting at 0 as level 1)")
-                .defineInRange("honey_bottle_effect_amplifier", 0, 0, 255);
-
-        BAKED_POTATO_EFFECT = builder
-                .comment("Determines what effect consuming Baked Potatoes will give")
-                .define("baked_potato_effect", "minecraft:strength");
-
-        BAKED_POTATO_EFFECT_DURATION = builder
-                .comment("Determines how long (in seconds) the Baked Potatoes Food Effect will last")
-                .defineInRange("baked_potato_effect_duration", 10.0, 0, 1000000);
-
-        BAKED_POTATO_EFFECT_AMPLIFIER = builder
-                .comment("Determines what level the Baked Potato Food Effect will be (starting at 0 as level 1)")
-                .defineInRange("baked_potato_effect_amplifier", 0, 0, 255);
-
-        CAKE_EFFECT = builder
-                .comment("Determines what effect consuming a slice of Cake will give")
-                .define("cake_effect", "minecraft:speed");
-
-        CAKE_EFFECT_DURATION = builder
-                .comment("Determines how long (in seconds) the Cake Food Effect will last")
-                .defineInRange("cake_effect_duration", 20.0, 0, 1000000);
-
-        CAKE_EFFECT_AMPLIFIER = builder
-                .comment("Determines what level the Cake Food Effect will be (starting at 0 as level 1)")
-                .defineInRange("cake_effect_amplifier", 1, 0, 255);
-
-        builder.pop();
+        @Configurable(description = "Determines what level the Cake Food Effect will be (starting at 0 as level 1)")
+        @IntegerRange(min = 0, max = 255)
+        public static int cake_effect_amplifier = 1;
     }
 }

--- a/src/main/java/org/infernalstudios/foodeffects/config/handler/EffectDataListConfigHandler.java
+++ b/src/main/java/org/infernalstudios/foodeffects/config/handler/EffectDataListConfigHandler.java
@@ -1,0 +1,56 @@
+package org.infernalstudios.foodeffects.config.handler;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import com.electronwill.nightconfig.core.Config;
+import com.google.common.collect.ImmutableList;
+
+import org.infernalstudios.config.element.ConfigElement;
+import org.infernalstudios.config.element.IConfigElement;
+import org.infernalstudios.config.element.handler.IConfigElementHandler;
+import org.infernalstudios.config.util.annotation.Nullable;
+import org.infernalstudios.foodeffects.EffectData;
+
+public class EffectDataListConfigHandler implements IConfigElementHandler<List<EffectData>, List<Config>> {
+    public static final EffectDataListConfigHandler INSTANCE = new EffectDataListConfigHandler();
+
+    private EffectDataListConfigHandler() {}
+
+    @Override
+    public IConfigElement<List<EffectData>> create(Field field) {
+        return new ConfigElement<>(field, this);
+    }
+
+    @Override
+    public IConfigElement<List<EffectData>> update(IConfigElement<List<EffectData>> element, @Nullable List<EffectData> obj) {
+        if (obj != null) {
+            element.set(ImmutableList.copyOf(obj));
+        }
+
+        return element;
+    }
+
+    @Override
+    public List<Config> serialize(IConfigElement<List<EffectData>> element) {
+        List<EffectData> value = element.getFromField();
+        if (value == null) {
+            value = element.getDefault();
+        }
+        return value.stream().map(EffectData::toConfig).collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    @Nullable
+    public List<EffectData> deserialize(List<Config> obj) {
+        if (obj != null) {
+            return obj.stream().map(EffectData::fromConfig).collect(ImmutableList.toImmutableList());
+        }
+        return null;
+    }
+
+    @Override
+    public boolean canHandle(Class<?> clazz) {
+        return clazz == List.class || clazz.isAssignableFrom(List.class);
+    }
+}

--- a/src/main/java/org/infernalstudios/foodeffects/mixin/MixinCakeBlock.java
+++ b/src/main/java/org/infernalstudios/foodeffects/mixin/MixinCakeBlock.java
@@ -1,19 +1,15 @@
 package org.infernalstudios.foodeffects.mixin;
 
-import static net.minecraftforge.registries.ForgeRegistries.MOB_EFFECTS;
-
-import org.infernalstudios.foodeffects.config.FoodEffectsConfig.Effects;
+import org.infernalstudios.foodeffects.FoodEffectsEvents;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.effect.MobEffect;
-import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.CakeBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -23,10 +19,6 @@ public class MixinCakeBlock {
 
     @Inject(method = "eat", at = @At(target = "Lnet/minecraft/world/entity/player/Player;awardStat(Lnet/minecraft/resources/ResourceLocation;)V", value = "INVOKE"))
     private static void FE_giveCakeEffect(LevelAccessor world, BlockPos pos, BlockState state, Player player, CallbackInfoReturnable<InteractionResult> cir) {
-        MobEffect cakeEffect = MOB_EFFECTS.getValue(new ResourceLocation(Effects.cake_effect));
-
-        if (cakeEffect != null) {
-            player.addEffect(new MobEffectInstance(cakeEffect, (int) (Effects.cake_effect_duration * 20), Effects.cake_effect_amplifier));
-        }
+        FoodEffectsEvents.onEat(player, Items.CAKE);
     }
 }

--- a/src/main/java/org/infernalstudios/foodeffects/mixin/MixinCakeBlock.java
+++ b/src/main/java/org/infernalstudios/foodeffects/mixin/MixinCakeBlock.java
@@ -1,8 +1,8 @@
 package org.infernalstudios.foodeffects.mixin;
 
 import static net.minecraftforge.registries.ForgeRegistries.MOB_EFFECTS;
-import static org.infernalstudios.foodeffects.config.FoodEffectsConfig.COMMON;
 
+import org.infernalstudios.foodeffects.config.FoodEffectsConfig.Effects;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -23,10 +23,10 @@ public class MixinCakeBlock {
 
     @Inject(method = "eat", at = @At(target = "Lnet/minecraft/world/entity/player/Player;awardStat(Lnet/minecraft/resources/ResourceLocation;)V", value = "INVOKE"))
     private static void FE_giveCakeEffect(LevelAccessor world, BlockPos pos, BlockState state, Player player, CallbackInfoReturnable<InteractionResult> cir) {
-        MobEffect cakeEffect = MOB_EFFECTS.getValue(new ResourceLocation(COMMON.CAKE_EFFECT.get()));
+        MobEffect cakeEffect = MOB_EFFECTS.getValue(new ResourceLocation(Effects.cake_effect));
 
         if (cakeEffect != null) {
-            player.addEffect(new MobEffectInstance(cakeEffect, (int) (COMMON.CAKE_EFFECT_DURATION.get() * 20), COMMON.CAKE_EFFECT_AMPLIFIER.get()));
+            player.addEffect(new MobEffectInstance(cakeEffect, (int) (Effects.cake_effect_duration * 20), Effects.cake_effect_amplifier));
         }
     }
 }


### PR DESCRIPTION
This PR implements the config with the `org.infernalstudios.config` library (see [FoodEffectsConfig.java](https://github.com/infernalexp/Food-Effects/tree/new-config/src/main/java/org/infernalstudios/foodeffects/config/FoodEffectsConfig.java)).

<details>
<summary>Explanation of <code>build.gradle</code></summary><br>

New dependencies:
```gradle
implementation "org.infernalstudios:config:2.1.1"
packIntoJar "org.infernalstudios:config:2.1.1"
```

`implementation` is meant for development purposes, to actually include the dependency in the build process.<br>
`packIntoJar` doesn't include the dependency when building, but is used as a marker for the shadow plugin.

The shadow plugin puts the dependency in the final jar, but remapped under a different package, as to avoid any possible mod incompatibilities.

The run configuration has changed to add the dependency to the classpath when running in a development environment.

</details>

Now, when running `gradlew build`, the jar with the "all" classifier should be distributed from the `build/libs` folder.

@Dariensg Need you to check my code for any problems
@nekomaster1000 Need you to sign off on this